### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/making-a-plugin/start.md
+++ b/docs/making-a-plugin/start.md
@@ -14,7 +14,7 @@ An example plugin can be found [here](https://github.com/Ellivers/worldtool-exam
 
 To get started, first create a new data pack with the following structure:
 
-`pack.mcmeta` - Your [pack.mcmeta](https://minecraft.fandom.com/wiki/Data_pack#pack.mcmeta) file.<br></br>
+`pack.mcmeta` - Your [pack.mcmeta](https://minecraft.wiki/w/Data_pack#pack.mcmeta) file.<br></br>
 `data`<br></br>
 &emsp;&emsp;`namespace` - Your own namespace, you can call it whatever you want.<br></br>
 &emsp;&emsp;&emsp;&emsp;`functions`<br></br>

--- a/docs/start.md
+++ b/docs/start.md
@@ -12,7 +12,7 @@ WorldTool is a world-editing data pack for Minecraft with a large variety of fea
 
 ## Setup
 
-* [Download](https://github.com/Ellivers/WorldTool/releases/download/v.0.6.1/WorldTool-0.6.1.zip) WorldTool. If you do not know how to install a data pack, refer to a guide such as [this one](https://minecraft.fandom.com/wiki/Tutorials/Installing_a_data_pack) (text) or [this one](https://youtu.be/C3zFd8pxFls) (video).
+* [Download](https://github.com/Ellivers/WorldTool/releases/download/v.0.6.1/WorldTool-0.6.1.zip) WorldTool. If you do not know how to install a data pack, refer to a guide such as [this one](https://minecraft.wiki/w/Tutorials/Installing_a_data_pack) (text) or [this one](https://youtu.be/C3zFd8pxFls) (video).
 * Make sure you have cheats enabled (singleplayer) or are an operator (server). If you are using this on a server, make sure the `enable-command-block` server property is enabled.
 * To finalize the installation of WorldTool, use the `/reload` command in-game, or restart the world.
 * Run the command `/function worldtool:give` in-game to recieve all the necessary tools to start your world editing!

--- a/docs/technical/area-storage-system.md
+++ b/docs/technical/area-storage-system.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Area Storage System
 
-WorldTool uses [structure blocks](https://minecraft.fandom.com/wiki/Structure_Block) to save areas with the [`save_area` process](processes#save-area) and load areas with the [`load_area` process](processes#load-area).
+WorldTool uses [structure blocks](https://minecraft.wiki/w/Structure_Block) to save areas with the [`save_area` process](processes#save-area) and load areas with the [`load_area` process](processes#load-area).
 #
 When used for purposes such as [undo/redo](../general-tool/options#undo-and-redo) and [copy/paste](../general-tool/options#copy-and-paste), the area data is stored on each indivual player using [PlayerDB](https://github.com/rx-modules/PlayerDB).
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki